### PR TITLE
SERVER-89226 Make tcmalloc cpu cache size consistent

### DIFF
--- a/tcmalloc/cpu_cache.h
+++ b/tcmalloc/cpu_cache.h
@@ -945,6 +945,7 @@ inline void CpuCache<Forwarder>::Activate() {
   //
   if (max_cache_size == kMaxCpuCacheSize) {
     max_cache_size = getMongoMaxCpuCacheSize(num_cpus);
+    SetCacheLimit(max_cache_size);
   }
 
 //////// END MONGO HACK


### PR DESCRIPTION
We have added in this mongo hack to resize the cpu caches, but need to update the system on what the new cpu cache size is as well.